### PR TITLE
Missing jquery.easing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": "5.3.1",
         "bootstrap": "4.1.3",
-        "jquery": "3.3.1"
+        "jquery": "3.3.1",
+        "jquery.easing": "1.4.1"
     },
     "devDependencies": {
         "browser-sync": "2.24.7",


### PR DESCRIPTION
Dependency on `jquery.easing` was absent in `package.json`, even though the library is present in `vendor`.