### PR TITLE
Remove Warning Message for "Replace Autoprefixer browsers"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,6 @@ function css() {
     }))
     .on("error", sass.logError)
     .pipe(autoprefixer({
-      browsers: ['last 2 versions'],
       cascade: false
     }))
     .pipe(header(banner, {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "type": "git",
         "url": "https://github.com/BlackrockDigital/startbootstrap-resume.git"
     },
+    "browserslist": ["last 2 versions"],
     "dependencies": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "bootstrap": "4.3.1",


### PR DESCRIPTION
Update `package.json` and `gulpfile.js` to remove "replace autoprefixer browsers" 

this is the message

```bash
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```