### PR TITLE
li's in the Awards & Certifications was congested in mobile and tab view

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*!
 * Start Bootstrap - Resume v7.0.6 (https://startbootstrap.com/theme/resume)
-* Copyright 2013-2023 Start Bootstrap
+* Copyright 2013-2024 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-resume/blob/master/LICENSE)
 */
 /*!

--- a/dist/index.html
+++ b/dist/index.html
@@ -175,39 +175,39 @@
                 <div class="resume-section-content">
                     <h2 class="mb-5">Awards & Certifications</h2>
                     <ul class="fa-ul mb-0">
-                        <li>
+                        <li class="mb-md-0 mb-2">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             Google Analytics Certified Developer
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             Mobile Web Specialist - Google Certification
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             1
                             <sup>st</sup>
                             Place - University of Colorado Boulder - Emerging Tech Competition 2009
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             1
                             <sup>st</sup>
                             Place - University of Colorado Boulder - Adobe Creative Jam 2008 (UI Design Category)
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             2
                             <sup>nd</sup>
                             Place - University of Colorado Boulder - Emerging Tech Competition 2008
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             1
                             <sup>st</sup>
                             Place - James Buchanan High School - Hackathon 2006
                         </li>
-                        <li>
+                        <li class="mb-md-0 mb-3">
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             3
                             <sup>rd</sup>

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -1,6 +1,6 @@
 /*!
 * Start Bootstrap - Resume v7.0.6 (https://startbootstrap.com/theme/resume)
-* Copyright 2013-2023 Start Bootstrap
+* Copyright 2013-2024 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-resume/blob/master/LICENSE)
 */
 //


### PR DESCRIPTION
Before
![Screenshot 2024-12-04 at 11 49 03 AM](https://github.com/user-attachments/assets/0e83f4f3-3799-410b-8fe3-ff00e13b3d18)
After
![Screenshot 2024-12-04 at 11 48 45 AM](https://github.com/user-attachments/assets/10b68903-9d08-434c-b5b5-ab8c1c02ccc1)
The li's in the Awards & Certifications was congested in mobile and tab view so I added margin-bottom only on mobile and tablet view using bootstrap utility class