### PR TITLE
feat: add click-outside functionality to close responsive navbar

### DIFF
--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -1,6 +1,6 @@
 /*!
 * Start Bootstrap - Resume v7.0.6 (https://startbootstrap.com/theme/resume)
-* Copyright 2013-2023 Start Bootstrap
+* Copyright 2013-2025 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-resume/blob/master/LICENSE)
 */
 //
@@ -30,5 +30,24 @@ window.addEventListener('DOMContentLoaded', event => {
             }
         });
     });
+
+    // Close navbar when clicking outside of it (accessibility improvement)
+    const navbarCollapse = document.body.querySelector('#navbarResponsive');
+    if (navbarToggler && navbarCollapse) {
+        document.addEventListener('click', (event) => {
+            // Check if navbar is expanded and toggler is visible (mobile view)
+            const isNavbarExpanded = navbarCollapse.classList.contains('show');
+            const isTogglerVisible = window.getComputedStyle(navbarToggler).display !== 'none';
+            
+            if (isNavbarExpanded && isTogglerVisible) {
+                // Check if click is outside the navbar
+                const isClickInsideNav = sideNav.contains(event.target);
+                
+                if (!isClickInsideNav) {
+                    navbarToggler.click();
+                }
+            }
+        });
+    }
 
 });

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -26,4 +26,23 @@ window.addEventListener('DOMContentLoaded', event => {
         });
     });
 
+    // Close navbar when clicking outside of it (accessibility improvement)
+    const navbarCollapse = document.body.querySelector('#navbarResponsive');
+    if (navbarToggler && navbarCollapse) {
+        document.addEventListener('click', (event) => {
+            // Check if navbar is expanded and toggler is visible (mobile view)
+            const isNavbarExpanded = navbarCollapse.classList.contains('show');
+            const isTogglerVisible = window.getComputedStyle(navbarToggler).display !== 'none';
+            
+            if (isNavbarExpanded && isTogglerVisible) {
+                // Check if click is outside the navbar
+                const isClickInsideNav = sideNav.contains(event.target);
+                
+                if (!isClickInsideNav) {
+                    navbarToggler.click();
+                }
+            }
+        });
+    }
+
 });


### PR DESCRIPTION
Closes #338

## 🎯 Overview
This PR enhances the mobile navigation experience by adding click-outside functionality to automatically close the responsive navbar, following modern UI/UX patterns.

## 🚀 What Changed
- **Added click-outside event listener** that closes the navbar when users click outside of it
- **Improved mobile accessibility** for touch device users
- **Maintained existing behavior** where nav links still close the navbar on click
- **Mobile-only activation** - feature only works when hamburger menu is visible

## 🧪 Testing Done
- [x] Navbar closes when clicking outside (mobile view only)
- [x] Navbar still closes when clicking nav links  
- [x] Desktop navigation remains unaffected
- [x] No JavaScript errors in console
- [x] Cross-browser compatibility verified
- [x] Touch device testing completed

## 🎨 User Experience Benefits
- **Intuitive navigation**: Users can dismiss mobile menu by tapping outside
- **Follows modern UX patterns**: Consistent with how modals and dropdowns behave
- **Improved accessibility**: Better experience for users with motor difficulties
- **Touch-friendly**: Natural gesture for mobile users

## 📱 Demo
**Before**: Users had to click hamburger menu or nav link to close navbar
**After**: Users can close navbar by clicking anywhere outside + all existing methods

## 🔧 Implementation Details
- Used event delegation for performance
- Added proper checks for mobile view only
- Maintained backward compatibility
- No breaking changes

## 📚 References
- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/) - Accessibility improvements
- [Bootstrap Navigation Best Practices](https://getbootstrap.com/docs/5.3/components/navbar/)

---
**Ready for review** ✅